### PR TITLE
Update README.md

### DIFF
--- a/releases/2.32/README.md
+++ b/releases/2.32/README.md
@@ -2,7 +2,7 @@
 
 ## System Administration
 - The *Server base URL* system setting has changed from being a system setting to a `dhis.conf` property. This is done because the server base URL typically follows the server and not the database. The setting key is `server.base.url`. See install guide for details.
-- Most metadata database tables now use *8-bit int* data type for the primary key column. This migration happens automatically. For the migration to succeed it is recommended to increase the PostgreSQL max locks per transaction setting such as `max_locks_per_transaction = 96`. See install guide for details.
+- Most metadata database tables now use *8-bit int* data type for the primary key column. This migration happens automatically. For the migration to succeed it is recommended to increase the PostgreSQL max locks per transaction setting such as `max_locks_per_transaction = 96`. See install guide for details. Note that this migration can take several hours, and that the database size may increase substantially during the process.
 - For Tomcat versions after 8.5, it is necessary to include a `relaxedQueryChars="[]"` attribute to allow for brackets in URLs in the `Connector` element in `server.xml`. See install guide for details.
 
 ## Data model


### PR DESCRIPTION
On the migration to use bigint: added that this can take hours and will increase the database size substantially. (Example with a real database running on a linode: 40GB => 200GB (without analytics) and over 5 hours). People (like me) might think that the startup is stuck, since there is not message in the tomcat log that this is happening.