### PR TITLE
refactor: normalize app version branches to 2.xx

### DIFF
--- a/tools/release-tags/branch_new_version.sh
+++ b/tools/release-tags/branch_new_version.sh
@@ -106,25 +106,15 @@ function get_new_master {
 }
 
 function app_branch_name {
-    # turns 2.31 or 2.31.1.12.23.3 into `v31`
+    # turns 2.31 or 2.31.1.12.23.3 into `2.31`
     # unless it is a feature-toggling app; in which case the branch is aways master
 
     if [[ " ${toggling_app_repos[@]} " =~ " $1 " ]]; then
         echo "master"
     else
-    if [[ "$1" =~ "data-visualizer-app" ]]; then
-
-                
         local RHS=${REL_VERSION#*.}
         local LHS=${RHS%%.*}
         echo "${LHS}.x"
-      else
-        local RHS=${REL_VERSION#*.}
-        local LHS=${RHS%%.*}
-        echo "v${LHS}"
-
-      fi
-
       fi
 
 }

--- a/tools/release-tags/lib/helpers.sh
+++ b/tools/release-tags/lib/helpers.sh
@@ -166,7 +166,7 @@ function get_new_master {
 }
 
 function app_branch_name {
-    # turns 2.31 or 2.31.1.12.23.3 into `v31`
+    # turns 2.31 or 2.31.1.12.23.3 into `2.31`
     # unless it is a feature-toggling app; in which case the branch is aways master
 
 
@@ -177,19 +177,9 @@ function app_branch_name {
         echo "master"
       fi
     else
-      if [[ "$1" =~ "data-visualizer-app" ]]; then
-
-
         local RHS=${REL_VERSION#*.}
         local LHS=${RHS%%.*}
         echo "${LHS}.x"
-      else
-        local RHS=${REL_VERSION#*.}
-        local LHS=${RHS%%.*}
-        echo "v${LHS}"
-
-      fi
-
     fi
 
 }

--- a/tools/release-tags/release.sh
+++ b/tools/release-tags/release.sh
@@ -159,7 +159,7 @@ function get_new_master {
 }
 
 function app_branch_name {
-    # turns 2.31 or 2.31.1.12.23.3 into `v31`
+    # turns 2.31 or 2.31.1.12.23.3 into `2.31`
     # unless it is a feature-toggling app; in which case the branch is aways master
 
 
@@ -170,19 +170,9 @@ function app_branch_name {
         echo "master"
       fi
     else
-      if [[ "$1" =~ "data-visualizer-app" ]]; then
-
-                
         local RHS=${REL_VERSION#*.}
         local LHS=${RHS%%.*}
         echo "${LHS}.x"
-      else
-        local RHS=${REL_VERSION#*.}
-        local LHS=${RHS%%.*}
-        echo "v${LHS}"
-
-      fi
-
     fi
 
 }


### PR DESCRIPTION
Hi @Philip-Larsen-Donnelly

I would like us to consider moving away from `v##` branches to the more predictable `2.##` to better match what is in JIRA and elsewhere.

It would involve more than what is in this PR, but using this as a base to start a discussion.