### PR TITLE
docs: program association in program stage

### DIFF
--- a/releases/2.38/README.md
+++ b/releases/2.38/README.md
@@ -6,7 +6,7 @@
 
 - Running jobs manually using `/api/jobConfigurations/execute` changed from 
   `GET` to `POST` request
-- Program id is now mandatory for program stage. 
+- Program id is now mandatory for program stage. Affected endpoints: /programStages, /metadata
 
 ## Authorities
 

--- a/releases/2.38/README.md
+++ b/releases/2.38/README.md
@@ -6,6 +6,7 @@
 
 - Running jobs manually using `/api/jobConfigurations/execute` changed from 
   `GET` to `POST` request
+- Program id is now mandatory for program stage. 
 
 ## Authorities
 


### PR DESCRIPTION
Previously, program association was not enforced on programStage. [This](https://jira.dhis2.org/browse/DHIS2-12129 ) jira issue fixed that. 