### PR TITLE
docs: document deprecated tracker APIs for 2.41

### DIFF
--- a/releases/2.41/README.md
+++ b/releases/2.41/README.md
@@ -41,6 +41,9 @@ following query parameters and paths in favor of new ones consistently using `tr
 `/tracker/relationships`
 * `trackedEntity` replaces `tei`
 
+`/tracker/events`
+* `attributeCategoryCombo` replaces `attributeCc`
+
 The following endpoints are deprecated
 
 * `/maintenance/softDeletedTrackedEntityRemoval` replaces `/maintenance/softDeletedTrackedEntityInstanceRemoval`


### PR DESCRIPTION
for https://github.com/dhis2/dhis2-core/pull/14096
