### PR TITLE
ci: upload stable.json to S3 on PR merge

### DIFF
--- a/.github/workflows/upload-stable-json.yml
+++ b/.github/workflows/upload-stable-json.yml
@@ -1,0 +1,26 @@
+name: Upload stable.json to S3
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+    paths:
+      - 'downloads/v1/versions/stable.json'
+
+jobs:
+  upload:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Upload stable.json to S3
+        uses: prewk/s3-cp-action@v2
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: eu-west-1
+          source: './downloads/v1/versions/stable.json'
+          dest: 's3://releases.dhis2.org/v1/versions/stable.json'


### PR DESCRIPTION
Tested triggering when a PR is merged with [an included path](https://github.com/dhis2/dhis2-releases/pull/177) and with [a not included path](https://github.com/dhis2/dhis2-releases/pull/176) and it seems to work as expected. Note that the test merge was done prior to setting up the S3 credentials, so the Upload step failed.