### PR TITLE
docs: Add upgrade notes advising of google and bing key removal in 2.41

### DIFF
--- a/releases/2.41/README.md
+++ b/releases/2.41/README.md
@@ -461,3 +461,6 @@ where relname = 'programstageinstance_pkey';
 Note that if you want to run the query, Postgres needs to start with `-c track_commit_timestamp=on`
 
 ## Deprecations and Removals
+
+### Google & Bing API keys removed
+The Google & Bing Map API keys were removed from the code. To setup and use a Bing Maps API key check [this guide](https://docs.dhis2.org/en/topics/tutorials/google-earth-engine-sign-up.html#accessing-bing-maps-basemaps).


### PR DESCRIPTION
The feature for removing the Google Map API key was included in the release notes features.
The task for removing the Bing Map API key was not included (possibly due to it missing a `fix version`)

Either way, it would be helpful if the upgrade notes included a note in the removal section advising of the removal of Google & Bing Map API keys from code.