### PR TITLE
chore: hotfix releases for DHIS2-21870

### DIFF
--- a/releases/2.41/ReleaseNote-2.41.9.1.md
+++ b/releases/2.41/ReleaseNote-2.41.9.1.md
@@ -1,0 +1,8 @@
+# Patch 41.9.1 Release Note
+
+DHIS2 version 41.9.1 is out as a HOTFIX release to address a critical issue affecting Tracker synchronisation in v41.9:
+
+- **[DHIS2-21870](https://dhis2.atlassian.net/browse/DHIS2-21870): Tracker import rejects valid IMAGE file resources with E1007 "invalid image format" (2.41/2.42)**  
+    Components: *\[API\] Tracker*
+
+See [Patch 41.9.0](https://github.com/dhis2/dhis2-releases/blob/master/releases/2.41/ReleaseNote-2.41.9.md) for the full list of fixes included in the parent patch release.

--- a/releases/2.42/ReleaseNote-2.42.5.2.md
+++ b/releases/2.42/ReleaseNote-2.42.5.2.md
@@ -1,0 +1,8 @@
+# Patch 42.5.2 Release Note
+
+DHIS2 version 41.5.2 is out as a HOTFIX release to address a critical issue affecting Tracker synchronisation in v42.5.x:
+
+- **[DHIS2-21870](https://dhis2.atlassian.net/browse/DHIS2-21870): Tracker import rejects valid IMAGE file resources with E1007 "invalid image format" (2.41/2.42)**  
+    Components: *\[API\] Tracker*
+
+See [Patch 42.5.1](https://github.com/dhis2/dhis2-releases/blob/master/releases/2.42/ReleaseNote-2.42.5.1.md) for the full list of fixes included in the parent patch release.


### PR DESCRIPTION
Added release note for DHIS2 version 42.5.2 addressing critical Tracker synchronisation issue.