### PR TITLE
docs: add v44 upgrade notes for the tracker export timeout DHIS2-21390

### DIFF
--- a/releases/2.44/README.md
+++ b/releases/2.44/README.md
@@ -27,5 +27,15 @@ Please note that both `createdBy` and `createdByUserInfo` are set server-side, s
 
 For TrackedEntityAttributeValues, the `storedBy` field has been renamed to `updatedBy`. It stores the authenticated user instead of the user provided in the payload, and is also set server-side, making it effectively read-only.
 
+#### Export requests are now bounded by a timeout
+
+Tracker export requests are now cancelled once they exceed a time budget, failing with `504 Gateway Timeout`.
+
+| Key | Default | Description |
+|---|---|---|
+| `tracker.export.timeout` | `600` | Seconds a tracker export request may spend fetching data. One budget is shared by every database query and object store read of a request. `0` disables it |
+
+10 minutes is a backstop so that no export runs unbounded, generous enough that typical workloads are unaffected. Set it below any timeout in front of DHIS2, such as a reverse proxy, so DHIS2 is the layer that times out first. See the [documentation](https://docs.dhis2.org/en/manage/reference/dhis-core-version-master/dhis.conf.html#install_tracker_configuration).
+
 
 ### Analytics


### PR DESCRIPTION
Calls out that tracker export requests are bounded by a timeout in v44, enabled by default with a 10 minute budget.

Core change: https://github.com/dhis2/dhis2-core/pull/25175
Docs: https://github.com/dhis2/dhis2-docs/pull/1795